### PR TITLE
Update docker-compose.logging.yml

### DIFF
--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -51,7 +51,7 @@ services:
   elasticsearch:
     image: elasticsearch:2
     ports:
-      9200:9200
+      - 9200:9200
     networks:
       - logging
       - monitoring_monitoring


### PR DESCRIPTION
fixed: services.elasticsearch.ports must be a list